### PR TITLE
remove pl as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ opencv-python-headless==4.5.5.64
 torch==1.11.0
 torchvision==0.12.0
 git+https://github.com/openai/CLIP.git
-pytorch-lightning==1.6.3


### PR DESCRIPTION
since `lightning` package install also `pytorch-lightning`, we don't need it as a dependency 