### PR TITLE
Fix fsspec version contradiction with Lightning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ git+https://github.com/kaushikb11/pytube.git
 lightning
 packaging==21.3
 fastapi[all]==0.78.0
-fsspec==2022.1.0
+fsspec[http]>=2021.05.0, !=2021.06.0, <2022.8.0
 py==1.11.0
 starsessions==1.2.3
 numpy==1.22.4


### PR DESCRIPTION
## What does this PR do?

This PR updates `fsspec` to be compatible with current Lightning. Due to the old requirement, we have to install very old Lightning now (`lightning-app==0.5.7`).

### Does your PR introduce any breaking changes? If yes, please list them.

No, it's just a fix.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue or with the team? (not for typos and docs)
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **test your PR locally**?
- [x] Did you **test your PR on cloud**?

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
